### PR TITLE
Fix a small log.info error

### DIFF
--- a/autonetkit/ank_messaging.py
+++ b/autonetkit/ank_messaging.py
@@ -104,7 +104,7 @@ def publish_data(data, type_key):
     try:
         data = urllib.urlopen(http_url, params).read()
     except IOError, e:
-        log.info("Unable to connect to HTTP Server %s: e" % (http_url, e))
+        log.info("Unable to connect to HTTP Server %s: %s" % (http_url, e))
 
 class AnkMessaging(object):
 


### PR DESCRIPTION
> File "autonetkit/ank_messaging.py", line 107, in publish_data
>     log.info("Unable to connect to HTTP Server %s: e" % (http_url, e))
> TypeError: not all arguments converted during string formatting

When trying to generate cfg's without having the visualisation server running
