### PR TITLE
Loopback interface needs to have an associated id with them

### DIFF
--- a/autonetkit/compilers/device/quagga.py
+++ b/autonetkit/compilers/device/quagga.py
@@ -2,7 +2,7 @@ from autonetkit.compilers.device.router_base import RouterCompiler
 
 class QuaggaCompiler(RouterCompiler):
     """Base Quagga compiler"""
-    lo_interface = "lo0:1"
+    lo_interface = "lo:1"
 
     def compile(self, node):
         super(QuaggaCompiler, self).compile(node)


### PR DESCRIPTION
I took the phy_int.interface_id (appended to the lo_interface_prefix:);
I do not think that loopbacks are supposed to have different id's depending on which kind of ip/... they are using but I might be wrong.
